### PR TITLE
cargo: bump trust-dns-resolver to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-trust-dns-resolver = "0.20"
+trust-dns-resolver = "0.21"
 hyper = { version = "0.14", features = ["tcp", "client"] }
 hyper-tls = { version = "0.5", optional = true }
 native-tls = { version = "0.2", optional = true }


### PR DESCRIPTION
Bump trust-dns-resolver to 0.21 version

cc @paullgdc 

