### PR TITLE
Upgrade to hickory-dns due to CVE-2024-12224

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-trust-dns-connector"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Paul Le Grand Des Cloizeaux <@paullgdc>"]
 edition = "2018"
 description = "A compatibility crate to use trust-dns-resolver asynchronously with hyper client, instead the default dns threadpool"
@@ -15,15 +15,15 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-trust-dns-resolver = "0.21"
+hickory-resolver = "0.24"
 hyper = { version = "0.14", features = ["tcp", "client"] }
 hyper-tls = { version = "0.5", optional = true }
 native-tls = { version = "0.2", optional = true }
 linked-hash-map = "0.5.3"
 
 [dev-dependencies]
-tokio = {version = "1.0.2", features = ["macros", "rt"]}
-hyper = { features = ["http1"] }
+tokio = { version = "1.0.2", features = ["macros", "rt"] }
+hyper = { version = "0.14", features = ["http1"] }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 //! }
 //! ```
 
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::TokioAsyncResolver;
 use hyper::client::connect::dns::Name;
 use hyper::client::HttpConnector;
 use hyper::service::Service;
@@ -41,8 +43,6 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{future::Future, net::SocketAddr, net::ToSocketAddrs};
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::TokioAsyncResolver;
 
 /// Wrapper around trust-dns-resolver's
 /// [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html)
@@ -57,7 +57,7 @@ impl AsyncHyperResolver {
     /// constructs a new resolver, arguments are passed to the corresponding method of
     /// [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html#method.new)
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> Result<Self, io::Error> {
-        let resolver = TokioAsyncResolver::tokio(config, options)?;
+        let resolver = TokioAsyncResolver::tokio(config, options);
         Ok(Self(resolver))
     }
 


### PR DESCRIPTION
A [CVE-2024-0421](https://osv.dev/vulnerability/RUSTSEC-2024-0421) has been reported in the [idna](https://crates.io/crates/idna/) crate, affecting all versions at or below 0.5. Idna is a dependency of trust-dns, which has now been moved to [hickory-dns](https://crates.io/crates/hickory-dns). The announcement for this move is available [here](https://bluejekyll.github.io/blog/posts/announcing-hickory-dns/).

This PR updates the dependencies to move to [hickory-dns](https://crates.io/crates/hickory-dns), which already uses idna 1.0.3, and hence resolves the CVE.