### PR TITLE
Update links and names in README and docuemntation to point to hickory-dns (trust-dns new name)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "hyper-trust-dns-connector"
 version = "0.5.0"
 authors = ["Paul Le Grand Des Cloizeaux <@paullgdc>"]
 edition = "2018"
-description = "A compatibility crate to use trust-dns-resolver asynchronously with hyper client, instead the default dns threadpool"
+description = "A compatibility crate to use hickory-dns asynchronously with hyper client, instead the default dns threadpool"
 repository = "https://github.com/paullgdc/hyper-trust-dns-connector"
 readme = "README.md"
 license = "MIT"
-keywords = ["resolver", "hyper", "trust-dns", "webclient", "async"]
+keywords = ["resolver", "hyper", "trust-dns", "hickory-dns", "webclient", "async"]
 categories = ["asynchronous", "web-programming::http-client", "network-programming"]
 
 [package.metadata.docs.rs]
@@ -19,6 +19,9 @@ hickory-resolver = "0.24"
 hyper = { version = "0.14", features = ["tcp", "client"] }
 hyper-tls = { version = "0.5", optional = true }
 native-tls = { version = "0.2", optional = true }
+# We depend on this crate indirectly.
+# This is pinned to >=0.5.3 because it contains UBs for lower versions
+# See https://github.com/contain-rs/lru-cache/issues/50
 linked-hash-map = "0.5.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://meritbadge.herokuapp.com/hyper-trust-dns-connector)](https://crates.io/crates/hyper-trust-dns-connector)
 [![Released API docs](https://docs.rs/hyper-trust-dns-connector/badge.svg)](https://docs.rs/hyper-trust-dns-connector)
 
-A crate to make [trust-dns-resolver](https://docs.rs/trust-dns-resolver)'s
+A crate to make [hickory-resolver](https://docs.rs/hickory-resolver/)'s (previously trust_dns_resolver)
 asynchronous resolver compatible with [hyper](https://docs.rs/hyper) client,
 to use instead of the default dns threadpool.
 
@@ -13,7 +13,7 @@ to use instead of the default dns threadpool.
 ## Motivations
 
 By default hyper HttpConnector uses the std provided resolver wich is blocking in a threadpool
-with a configurable number of threads. This crate provides an alternative using trust_dns_resolver,
+with a configurable number of threads. This crate provides an alternative using hickory-resolver,
 a dns resolver written in Rust, with async features.
 
 ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! # hyper_trust_dns_connector
 //!
-//! A crate to make [trust-dns-resolver](https://docs.rs/trust-dns-resolver)'s
+//! A crate to make [hickory-resolver](https://docs.rs/hickory-resolver/)'s (previously trust_dns_resolver)
 //! asynchronous resolver compatible with [hyper](https://docs.rs/hyper) client,
 //! to use instead of the default dns threadpool.
 //!
@@ -14,7 +14,7 @@
 //!
 //! ## Usage
 //!
-//! [trust-dns-resolver](https://docs.rs/trust-dns-resolver) creates an async resolver
+//! [hickory-resolver](https://docs.rs/hickory-resolver/) creates an async resolver
 //! for dns queries, which is then used by hyper
 //!
 //! ## Example
@@ -44,8 +44,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{future::Future, net::SocketAddr, net::ToSocketAddrs};
 
-/// Wrapper around trust-dns-resolver's
-/// [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html)
+/// Wrapper around hickory-resolver's
+/// [`TokioAsyncResolver`](https://docs.rs/hickory-resolver/0.24.2/hickory_resolver/type.TokioAsyncResolver.html)
 ///
 /// The resolver runs a background Task which manages dns requests. When a new resolver is created,
 /// the background task is also created, it needs to be spawned on top of an executor before using the client,
@@ -55,14 +55,14 @@ pub struct AsyncHyperResolver(TokioAsyncResolver);
 
 impl AsyncHyperResolver {
     /// constructs a new resolver, arguments are passed to the corresponding method of
-    /// [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html#method.new)
+    /// [`TokioAsyncResolver`](https://docs.rs/hickory-resolver/0.24.2/hickory_resolver/struct.AsyncResolver.html#method.new)
     pub fn new(config: ResolverConfig, options: ResolverOpts) -> Result<Self, io::Error> {
         let resolver = TokioAsyncResolver::tokio(config, options);
         Ok(Self(resolver))
     }
 
     /// constructs a new resolver from default configuration, uses the corresponding method of
-    /// [`TokioAsyncResolver`](https://docs.rs/trust-dns-resolver/0.20.0/trust_dns_resolver/type.TokioAsyncResolver.html#method.new)
+    /// [`TokioAsyncResolver`](https://docs.rs/hickory-resolver/0.24.2/hickory_resolver/struct.AsyncResolver.html#method.tokio_from_system_conf)
     pub fn new_from_system_conf() -> Result<Self, io::Error> {
         let resolver = TokioAsyncResolver::tokio_from_system_conf()?;
         Ok(Self(resolver))


### PR DESCRIPTION
# Motivations

trust-dns renamed itself to hickory-dns for new versions.
We started depending on hickory-resolver since #8 so this PR updates documentation before pushing a new crate version to crates.io